### PR TITLE
Remove all target attributes from links

### DIFF
--- a/source/blog/2018-10-25-open-source-brand-design-for-simple.html.erb
+++ b/source/blog/2018-10-25-open-source-brand-design-for-simple.html.erb
@@ -32,7 +32,7 @@ author_details: "Product and Design, Canada"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-08-06-how-a-simulated-clinic-helps-us-make-better-software.html.erb
+++ b/source/blog/2019-08-06-how-a-simulated-clinic-helps-us-make-better-software.html.erb
@@ -26,7 +26,7 @@ author_details: "User testing, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>"> 
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-08-22-how-storyboarding-from-real-data-drives-good-product-decisions.html.erb
+++ b/source/blog/2019-08-22-how-storyboarding-from-real-data-drives-good-product-decisions.html.erb
@@ -32,7 +32,7 @@ author_details: "Design, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>"> 
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-09-03-5-articles-to-convince-leaders.html.erb
+++ b/source/blog/2019-09-03-5-articles-to-convince-leaders.html.erb
@@ -32,7 +32,7 @@ author_details: "Product and Design, Canada"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-09-18-what-we-are-learning.html.erb
+++ b/source/blog/2019-09-18-what-we-are-learning.html.erb
@@ -32,7 +32,7 @@ author_details: "Product and Design, Canada"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-10-04-training-the-simple-way.html.erb
+++ b/source/blog/2019-10-04-training-the-simple-way.html.erb
@@ -26,7 +26,7 @@ author_details: "Project management, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-10-10-a-day-in-the-life.html.erb
+++ b/source/blog/2019-10-10-a-day-in-the-life.html.erb
@@ -26,7 +26,7 @@ author_details: "Design, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-11-20-phone-interviews-with-users.html.erb
+++ b/source/blog/2019-11-20-phone-interviews-with-users.html.erb
@@ -26,7 +26,7 @@ author_details: "User testing, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>"> 
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2019-12-17-co-creation-with-nurses.html.erb
+++ b/source/blog/2019-12-17-co-creation-with-nurses.html.erb
@@ -32,7 +32,7 @@ author_details: "Design, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/blog/2020-01-02-offline-first-apps.html.erb
+++ b/source/blog/2020-01-02-offline-first-apps.html.erb
@@ -26,7 +26,7 @@ author_details: "Development, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>
@@ -37,7 +37,7 @@ author_details: "Development, India"
 <div class="article-content">
   <section>
     <p>
-      Let me set the scene. A nurse named Ravdeep works in a busy clinic in a rural hospital in India. Patients are lined up outside her door in a chaotic line all of the way down the hall. Ravdeep is responsible for taking blood pressures and blood sugar measures for each patient. She quickly enters their data into the <a href="https://simple.org" target="_blank">Simple</a> app on her tablet, and sends them to the doctor if they appear to be hypertensive or diabetic.
+      Let me set the scene. A nurse named Ravdeep works in a busy clinic in a rural hospital in India. Patients are lined up outside her door in a chaotic line all of the way down the hall. Ravdeep is responsible for taking blood pressures and blood sugar measures for each patient. She quickly enters their data into the <a href="https://simple.org">Simple</a> app on her tablet, and sends them to the doctor if they appear to be hypertensive or diabetic.
     </p>
     <p>
       This public hospital isn’t fancy, but you might be surprised to know that Ravdeep’s clinic has excellent 4G internet. In fact, much of India is covered with strong, affordable mobile networks. So, why would we choose to make an app like Simple using an offline-first approach?

--- a/source/blog/2020-02-12-simple-wins-best-in-show.html.erb
+++ b/source/blog/2020-02-12-simple-wins-best-in-show.html.erb
@@ -26,7 +26,7 @@ author_details: "Design, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>
@@ -37,19 +37,19 @@ author_details: "Design, India"
 <div class="article-content">
   <section>
     <p>
-      Our goal with <a href="https://simple.org/" target="_blank">Simple</a> is to make clinicians’ work life easier and to improve patient outcomes across entire populations. In fast-paced, under-resourced clinics, that’s a surprisingly tough task, riddled with many challenges. The one fundamental question that we ask ourselves as we design solutions is “are we designing just an app that records patient data or interventions that will shape real world interactions between clinicians and their patients to reinforce positive behaviour?”
+      Our goal with <a href="https://simple.org/">Simple</a> is to make clinicians’ work life easier and to improve patient outcomes across entire populations. In fast-paced, under-resourced clinics, that’s a surprisingly tough task, riddled with many challenges. The one fundamental question that we ask ourselves as we design solutions is “are we designing just an app that records patient data or interventions that will shape real world interactions between clinicians and their patients to reinforce positive behaviour?”
     </p>
     <p>
-      A lot of our design methods come from the discipline of interaction design, which Richard Buchanan describes beautifully as “designing how people relate to other people through the mediating influence of products.” <a href="https://ixda.org/" target="_blank">The Interaction Design Association</a> (IxDA) is a global community of pioneers and practitioners dedicated to this discipline. Launched in 2003, the IxDA has over 100,000 members and over 200 local groups around the world.
+      A lot of our design methods come from the discipline of interaction design, which Richard Buchanan describes beautifully as “designing how people relate to other people through the mediating influence of products.” <a href="https://ixda.org/">The Interaction Design Association</a> (IxDA) is a global community of pioneers and practitioners dedicated to this discipline. Launched in 2003, the IxDA has over 100,000 members and over 200 local groups around the world.
     </p>
     <p>
-      This year, at the annual worldwide IxDA conference, the <a href="https://simple.org/" target="_blank">Simple project</a> took home the top prize. We couldn’t be more proud!
+      This year, at the annual worldwide IxDA conference, the <a href="https://simple.org/">Simple project</a> took home the top prize. We couldn’t be more proud!
     </p>
     <div class="quote">
       <p>
         Learn more about Simple
       </p>
-      <a class="fs-xlarge" href="#" target="_blank">
+      <a class="fs-xlarge" href="#">
         What we are learning by creating an ultra-thin EMR
       </a>
     </div>
@@ -68,7 +68,7 @@ author_details: "Design, India"
       Simple isn’t the result of any one person’s work, but is the result of awe-inspiring team effort that has brought a diverse group of incredible individuals and institutions to collaborate together. Healthcare workers, in particular, are crucial to the success of Simple and their feedback and ideas enable Simple to actually work in challenging clinical environments.
     </p>
     <p>
-      Design and development of Simple is based in Bangalore and much of the hands-on work comes out of the teams at <a href="https://obvious.in/" target="_blank">Obvious</a> and <a href="https://nilenso.com/" target="_blank">Nilenso</a>. As a design and development team, we work as one cohesive unit where the boundaries between the two often dissolve in pursuit of keeping Simple human-centered. Our approach is research-driven and we are constantly in the field, learning from clinicians and patients.
+      Design and development of Simple is based in Bangalore and much of the hands-on work comes out of the teams at <a href="https://obvious.in/">Obvious</a> and <a href="https://nilenso.com/">Nilenso</a>. As a design and development team, we work as one cohesive unit where the boundaries between the two often dissolve in pursuit of keeping Simple human-centered. Our approach is research-driven and we are constantly in the field, learning from clinicians and patients.
     </p>
     <p>
       This free and open-source project is made in India, to be used in India and to be exported around the world for non-communicable disease programmes. In the next few months, Simple will also launch in Bangladesh and Ethiopia.
@@ -99,29 +99,29 @@ author_details: "Design, India"
       Thank you to the jury
     </h2>
     <p>
-      Thank you to the <a href="https://awards.ixda.org/jury/" target="_blank">IxDA Awards jury</a> for selecting <a href="https://simple.org/" target="_blank">Simple</a> as “Best in Show”:
+      Thank you to the <a href="https://awards.ixda.org/jury/">IxDA Awards jury</a> for selecting <a href="https://simple.org/">Simple</a> as “Best in Show”:
     </p>
     <ul>
       <li>
-        <a href="https://medium.com/u/527d9b9e27b9?source=post_page-----a1c3a30a7d30----------------------" target="_blank">Dan Makoski</a>, Chief Design Officer at <a href="https://www.lloydsbankinggroup.com/" target="_blank">Lloyds Banking Group</a>
+        <a href="https://medium.com/u/527d9b9e27b9?source=post_page-----a1c3a30a7d30----------------------">Dan Makoski</a>, Chief Design Officer at <a href="https://www.lloydsbankinggroup.com/">Lloyds Banking Group</a>
       </li>
       <li>
-        <a href="https://twitter.com/apekshagarga" target="_blank">Apeksha Garga</a>, VP of Design at <a href="https://www.wealthfront.com/" target="_blank">Wealthfront</a>
+        <a href="https://twitter.com/apekshagarga">Apeksha Garga</a>, VP of Design at <a href="https://www.wealthfront.com/">Wealthfront</a>
       </li>
       <li>
-        <a href="https://medium.com/u/50e39baefa55?source=post_page-----a1c3a30a7d30----------------------" target="_blank">Fabricio Teixeira</a>, Design director at <a href="https://work.co/" target="_blank">Work & Co</a> in Brooklyn and Founder of UX Collective.
+        <a href="https://medium.com/u/50e39baefa55?source=post_page-----a1c3a30a7d30----------------------">Fabricio Teixeira</a>, Design director at <a href="https://work.co/">Work & Co</a> in Brooklyn and Founder of UX Collective.
       </li>
       <li>
-        <a href="https://awards.ixda.org/juror/2020-nicola-ralston/" target="_blank">Nicola Ralston</a>, Senior Director of Design, Microsoft
+        <a href="https://awards.ixda.org/juror/2020-nicola-ralston/">Nicola Ralston</a>, Senior Director of Design, Microsoft
       </li>
       <li>
-        <a href="https://medium.com/u/9a26066b044a?source=post_page-----a1c3a30a7d30----------------------" target="_blank">Kevin Budelmann</a>, <a href="https://peopledesign.com/" target="_blank">President of Peopledesign</a>, Global VP of <a href="https://ixda.org/" target="_blank">IxDA</a>, and adjunct professor at Northwestern University
+        <a href="https://medium.com/u/9a26066b044a?source=post_page-----a1c3a30a7d30----------------------">Kevin Budelmann</a>, <a href="https://peopledesign.com/">President of Peopledesign</a>, Global VP of <a href="https://ixda.org/">IxDA</a>, and adjunct professor at Northwestern University
       </li>
       <li>
-        <a href="https://awards.ixda.org/juror/2020-nicolas-jauguiberry/" target="_blank">Nicolás Jauguiberry</a>, Design Manager at Galicia Bank, and educator at UCA and ITBA
+        <a href="https://awards.ixda.org/juror/2020-nicolas-jauguiberry/">Nicolás Jauguiberry</a>, Design Manager at Galicia Bank, and educator at UCA and ITBA
       </li>
       <li>
-        <a href="https://medium.com/u/941eb466ccd0?source=post_page-----a1c3a30a7d30----------------------" target="_blank">Yasaman Sheri</a>, leading special projects on Augmented Intelligence at SPACE10 and educator at the RISD and CIID
+        <a href="https://medium.com/u/941eb466ccd0?source=post_page-----a1c3a30a7d30----------------------">Yasaman Sheri</a>, leading special projects on Augmented Intelligence at SPACE10 and educator at the RISD and CIID
       </li>
     </ul>
   </section>
@@ -131,7 +131,7 @@ author_details: "Design, India"
       alt="Mahima Chandak, Daniel Burka, and Akshay Verma were in Milan to receive the award on behalf of the Simple team."
     />
     <h4>
-      <a href="https://twitter.com/mahima_chandak" target="_blank">Mahima Chandak</a>, <a href="https://twitter.com/dburka" target="_blank">Daniel Burka</a>, and <a href="<%= current_page.data.author_social_link %>" target="_blank">Akshay Verma</a> were in Milan to receive the award on behalf of the <a href="https://simple.org/about" target="_blank">Simple team</a>.
+      <a href="https://twitter.com/mahima_chandak">Mahima Chandak</a>, <a href="https://twitter.com/dburka">Daniel Burka</a>, and <a href="<%= current_page.data.author_social_link %>">Akshay Verma</a> were in Milan to receive the award on behalf of the <a href="https://simple.org/about">Simple team</a>.
     </h4>
   </div>
   <section>

--- a/source/blog/2020-02-25-simple-and-bangladesh.html.erb
+++ b/source/blog/2020-02-25-simple-and-bangladesh.html.erb
@@ -32,7 +32,7 @@ author_details: "User testing, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>
@@ -43,10 +43,10 @@ author_details: "User testing, India"
 <div class="article-content">
   <section>
     <p>
-      We are very excited this week that <a href="https://simple.org/" target="_blank">Simple</a> was deployed in for the first time outside India. This week, we launched Simple in four large Upazila Health Complexes in Sylhet in northern Bangladesh.
+      We are very excited this week that <a href="https://simple.org/"Simple</a> was deployed in for the first time outside India. This week, we launched Simple in four large Upazila Health Complexes in Sylhet in northern Bangladesh.
     </p>
     <p>
-      Nurses and doctors in Bangladesh often see an extraordinary number of patients each day. In fact, Bangladesh has some of the fastest, highest volume primary care in the world (<a href="https://bmjopen.bmj.com/content/7/10/e017902" target="_blank">1</a>). It’s common to see a long line of patients waiting to have their blood pressures taken and to pick up medications to manage their hypertension.
+      Nurses and doctors in Bangladesh often see an extraordinary number of patients each day. In fact, Bangladesh has some of the fastest, highest volume primary care in the world (<a href="https://bmjopen.bmj.com/content/7/10/e017902">1</a>). It’s common to see a long line of patients waiting to have their blood pressures taken and to pick up medications to manage their hypertension.
     </p>
     <p>
       In this environment, it’s critical that record-keeping be very <dfn>efficient</dfn> so nurses and doctors can focus on patient care. This is where Simple comes in. At fast-paced hospitals, clinicians can spend less time recording patient details on paper and quickly create and maintain longitudinal records that improve care.
@@ -57,7 +57,7 @@ author_details: "User testing, India"
       </p>
     </div>
     <p>
-      In Bangladesh, we partner with the Government of Bangladesh (Non-Communicable Diseases Control Program, Directorate General of Health Services, Ministry of Health and Family Welfare) and the <a href="http://www.nhf.org.bd/" target="_blank">National Heart Foundation</a> of Bangladesh on a hypertension control initiative. Their program is a remarkable achievement that aims to significantly reduce deaths from heart attacks and strokes.
+      In Bangladesh, we partner with the Government of Bangladesh (Non-Communicable Diseases Control Program, Directorate General of Health Services, Ministry of Health and Family Welfare) and the <a href="http://www.nhf.org.bd/">National Heart Foundation</a> of Bangladesh on a hypertension control initiative. Their program is a remarkable achievement that aims to significantly reduce deaths from heart attacks and strokes.
     </p>
   </section>
   <div class="image--wide">
@@ -66,7 +66,7 @@ author_details: "User testing, India"
       alt="Staff nurses being trained to use Simple in Sylhet, Bangladesh"
     />
     <h4 class="image-description">
-      Staff nurses being trained to use <a href="https://simple.org/" target="_blank">Simple</a> in Sylhet, Bangladesh
+      Staff nurses being trained to use <a href="https://simple.org/">Simple</a> in Sylhet, Bangladesh
     </h4>
   </div>
   <div class="image--wide">
@@ -75,12 +75,12 @@ author_details: "User testing, India"
       alt="Staff nurses using Simple for the first time"
     />
     <h4 class="image-description">
-      Staff nurses using <a href="https://simple.org/" target="_blank">Simple</a> for the first time
+      Staff nurses using <a href="https://simple.org/">Simple</a> for the first time
     </h4>
   </div>
   <section>
     <p>
-      To learn more, visit <a href="https://simple.org" target="_blank"><b>Simple.org</b></a>
+      To learn more, visit <a href="https://simple.org"><b>Simple.org</b></a>
     </p>
   </section>
 </div>

--- a/source/blog/2020-03-20-hiring-senior-rails-developer.html.erb
+++ b/source/blog/2020-03-20-hiring-senior-rails-developer.html.erb
@@ -32,7 +32,7 @@ author_details: "Development, USA"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>
@@ -43,13 +43,13 @@ author_details: "Development, USA"
 <div class="article-content">
   <section>
     <p>
-      <a href="https://www.simple.org/" target="_blank"><b>Simple</b></a> is a free, open source app developed by <a href="https://www.resolvetosavelives.org/" target="_blank">Resolve to Save Lives</a> (an initiative of <a href="http://vitalstrategies.org/" target="_blank">Vital Strategies</a>) and is used by nurses, doctors, and population health experts to improve treatment for patients with high blood pressure.
+      <a href="https://www.simple.org/"><b>Simple</b></a> is a free, open source app developed by <a href="https://www.resolvetosavelives.org/">Resolve to Save Lives</a> (an initiative of <a href="http://vitalstrategies.org/">Vital Strategies</a>) and is used by nurses, doctors, and population health experts to improve treatment for patients with high blood pressure.
     </p>
     <p>
-      Simple is currently used in several states of India as well as in Bangladesh. It is used to manage over 200,000 patients in about 600 hospitals, with plans for deployment in additional program focus countries in 2020. Our goal is to save 100 million lives from heart attacks and strokes (<a href="https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32443-1/fulltext" target="_blank">The Lancet</a>).
+      Simple is currently used in several states of India as well as in Bangladesh. It is used to manage over 200,000 patients in about 600 hospitals, with plans for deployment in additional program focus countries in 2020. Our goal is to save 100 million lives from heart attacks and strokes (<a href="https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32443-1/fulltext">The Lancet</a>).
     </p>
     <p>
-      Learn more about the Simple project at <a href="https://www.simple.org/" target="_blank">Simple.org</a> and in <a href="#" target="_blank">this article</a>.
+      Learn more about the Simple project at <a href="https://www.simple.org/">Simple.org</a> and in <a href="#">this article</a>.
     </p>
   </section>
   <section>
@@ -188,7 +188,7 @@ author_details: "Development, USA"
     <p>
       Please take the time to describe yourself and why you’ll be a great fit for this project. We encourage people of under-represented backgrounds to apply even if you took an unconventional path to become a developer.
     </p>
-    <a href="https://chp.tbe.taleo.net/chp01/ats/careers/v2/viewRequisition?org=VITASTRA&cws=37&rid=152" target="_blank">
+    <a href="https://chp.tbe.taleo.net/chp01/ats/careers/v2/viewRequisition?org=VITASTRA&cws=37&rid=152">
       <b>👉 Submit your application here…</b>
     </a>
   </section>
@@ -197,7 +197,7 @@ author_details: "Development, USA"
       Questions?
     </h2>
     <p>
-      Please ask questions in the comments below or DM me on Twitter: <a href="<%= current_page.data.author_social_link %>" target="_blank">twitter.com/timcheadle</a>
+      Please ask questions in the comments below or DM me on Twitter: <a href="<%= current_page.data.author_social_link %>">twitter.com/timcheadle</a>
     </p>
   </section>
 </div>

--- a/source/blog/2020-06-08-remote-user-testing-during-lockdown.html.erb
+++ b/source/blog/2020-06-08-remote-user-testing-during-lockdown.html.erb
@@ -26,7 +26,7 @@ author_details: "Design, India"
     />
     <div class="person--details">
       <h3>
-        <a href="<%= current_page.data.author_social_link %>" target="_blank">
+        <a href="<%= current_page.data.author_social_link %>">
           <%= current_page.data.author %>
         </a>
       </h3>

--- a/source/localizable/blog.html.erb
+++ b/source/localizable/blog.html.erb
@@ -41,7 +41,7 @@ social: social.jpg
           />
           <div class="person--details">
             <h3>
-              <a href="<%= article.data.author_social_link %>" target="_blank">
+              <a href="<%= article.data.author_social_link %>">
                 <%= article.data.author %>
               </a>
              </h3>
@@ -91,7 +91,7 @@ social: social.jpg
             />
             <div class="person--details">
               <h3>
-                <a href="<%= article.data.author_social_link %>" target="_blank">
+                <a href="<%= article.data.author_social_link %>">
                   <%= article.data.author %>
                 </a>
               </h3>


### PR DESCRIPTION
Removed all `target="_blank"` from article links. No need to open a new tab.