### PR TITLE
Missing hyperlinks

### DIFF
--- a/source/blog/2020-02-12-simple-wins-best-in-show.html.erb
+++ b/source/blog/2020-02-12-simple-wins-best-in-show.html.erb
@@ -33,7 +33,7 @@ author: "Akshay Verma"
     This year, at the annual worldwide IxDA conference, the <a href="https://simple.org/">Simple project</a> took home the top prize. We couldn’t be more proud!
   </p>
   <p>
-    If you'd like to learn more about Simple, read <a href="https://www.simple.org/blog/what-we-are-learning">"What we are learning by creating an ultra-thin EMR"</a>.
+    Learn more about the Simple project at <a href="https://www.simple.org/">Simple.org</a> and in <a href="https://www.simple.org/blog/what-we-are-learning">this article</a>.
   </p>
 </section>
 <div class="image--wide">

--- a/source/blog/2020-02-12-simple-wins-best-in-show.html.erb
+++ b/source/blog/2020-02-12-simple-wins-best-in-show.html.erb
@@ -32,14 +32,9 @@ author: "Akshay Verma"
   <p>
     This year, at the annual worldwide IxDA conference, the <a href="https://simple.org/">Simple project</a> took home the top prize. We couldn’t be more proud!
   </p>
-  <div class="quote">
-    <p>
-      Learn more about Simple
-    </p>
-    <a class="fs-xlarge" href="#">
-      What we are learning by creating an ultra-thin EMR
-    </a>
-  </div>
+  <p>
+    If you'd like to learn more about Simple, read <a href="https://www.simple.org/blog/what-we-are-learning">"What we are learning by creating an ultra-thin EMR"</a>.
+  </p>
 </section>
 <div class="image--wide">
   <img

--- a/source/blog/2020-03-20-hiring-senior-rails-developer.html.erb
+++ b/source/blog/2020-03-20-hiring-senior-rails-developer.html.erb
@@ -17,7 +17,7 @@ author: "Tim Cheadle"
     Simple is currently used in several states of India as well as in Bangladesh. It is used to manage over 200,000 patients in about 600 hospitals, with plans for deployment in additional program focus countries in 2020. Our goal is to save 100 million lives from heart attacks and strokes (<a href="https://www.thelancet.com/journals/lancet/article/PIIS0140-6736(17)32443-1/fulltext">The Lancet</a>).
   </p>
   <p>
-    Learn more about the Simple project at <a href="https://www.simple.org/">Simple.org</a> and in <a href="#">this article</a>.
+    Learn more about the Simple project at <a href="https://www.simple.org/">Simple.org</a> and in <a href="https://www.simple.org/blog/what-we-are-learning">this article</a>.
   </p>
 </section>
 <section>


### PR DESCRIPTION
**Summary**
2 articles had empty `href` originally linked to "What we are learning by building an ultra-thin EMR".

---

**Details**
* Added link to "Simple Wins 'Best in Show' at the IxDA Awards in Milan"
* Added link to "Hiring: Senior Rails Developer"

---

**Screenshots**

![image](https://user-images.githubusercontent.com/16785131/86520137-43d46000-be0f-11ea-8327-64519a8a53d7.png)