### PR TITLE
Bug: Blog row display bug

### DIFF
--- a/source/localizable/blog.html.erb
+++ b/source/localizable/blog.html.erb
@@ -61,6 +61,7 @@ social: social.jpg
     <% if index == 0 || index % 3 == 0 %>
       <div class="articles--normal">
     <% end %>
+      <!-- <%= index %> -->
       <div class="article-preview">
         <a href="<%= article.url %>" class="article-preview--cover">
           <img
@@ -106,7 +107,7 @@ social: social.jpg
           </div>
         </div>
       </div>
-    <% if index + 1 % 3 == 0 %>
+    <% if (index + 1) % 3 == 0 %>
       </div>
     <% end %>
   <% end %>

--- a/source/localizable/blog.html.erb
+++ b/source/localizable/blog.html.erb
@@ -61,7 +61,6 @@ social: social.jpg
     <% if index == 0 || index % 3 == 0 %>
       <div class="articles--normal">
     <% end %>
-      <!-- <%= index %> -->
       <div class="article-preview">
         <a href="<%= article.url %>" class="article-preview--cover">
           <img


### PR DESCRIPTION
**Summary**
For larger devices, blog page was showing 1 article in a row that should have 3 previews. It now displays rows of 3-by-3 after the first 2 large articles.

---

**Details**
* Injecting `<div class="articles--normal">` at proper index
* Injection `</div>` at proper index

---

**Screenshots**

![image](https://user-images.githubusercontent.com/16785131/86520590-38376800-be14-11ea-9052-3eba1f2178d9.png)