### PR TITLE
Fixed image-width bug

### DIFF
--- a/source/stylesheets/_blog.scss
+++ b/source/stylesheets/_blog.scss
@@ -616,7 +616,6 @@ $width-xlarge: 1192px;
 	margin-left: auto;
 }
 img {
-	width: 100%;
 	max-width: 100%;
 }
 


### PR DESCRIPTION
**Summary**
Image styling in `_blog.scss` was breaking images across the site. Bug is temporarily fixed.

---

**Details**
* Removed `width: 100%;` from `img` in `_blog.scss`

---

**Screenshots**
*No significant visual changes*