### PR TITLE
Fixed blog styling

### DIFF
--- a/source/layouts/article.erb
+++ b/source/layouts/article.erb
@@ -43,7 +43,7 @@
     <meta name="twitter:image:alt"         content="<%= current_page.data.cover_image_alt %>">
     <!-- CSS
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <%= stylesheet_link_tag "site" %>
+    <%= stylesheet_link_tag "blog" %>
     <style type="text/css">
       <% if lang != :en %>
         h3 { font-weight: 900; font-size: 22px; }

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -41,7 +41,7 @@
     <meta name="twitter:image:src" content="https://simple.org/images/<%= current_page.data.social %>">
     <!-- CSS
     –––––––––––––––––––––––––––––––––––––––––––––––––– -->
-    <%= stylesheet_link_tag "site" %>
+    <%= stylesheet_link_tag "blog" %>
     <style type="text/css">
       <% if lang != :en %>
         h3 { font-weight: 900; font-size: 22px; }

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -1,3 +1,4 @@
 @import "normalize";
 @import "skeleton";
 @import "base";
+@import "blog";


### PR DESCRIPTION
**Summary**
Blog styling declarations were overriding site styling. Created a new `blog.css.scss` to scope article styles to blog section.