### PR TITLE
Nav hover red

### DIFF
--- a/source/stylesheets/_base.scss
+++ b/source/stylesheets/_base.scss
@@ -254,7 +254,7 @@ nav span {
 }
 
 nav a.link:hover {
-    color: #0075EB;
+    color: #FF3355;
 }
 
 nav .nav-links {


### PR DESCRIPTION
**Summary**
Changed navigation link hover from red to blue to match active color.

---

**Screenshot**

![image](https://user-images.githubusercontent.com/16785131/87546845-36716e00-c678-11ea-8d06-2d262aeddd74.png)