### PR TITLE
Removed nav stylebar in mobile article template

### DIFF
--- a/source/layouts/article.erb
+++ b/source/layouts/article.erb
@@ -75,7 +75,6 @@
     <link rel="icon" type="image/png" href="/images/favicon.png">
   </head>
   <body class="<%= t(:lang) %> body-blog">
-    <div class="h-20px bg-dark-blue d-none-large"></div>
     <div class="mr-45pt-large p-20px pt-80px-large px-0px-large">
       <div class="mw-600px mx-auto-large">
         <%= partial "partials/nav" %>


### PR DESCRIPTION
**Summary**
Removed mobile nav stylebar from article template

---

**Screenshot**

![image](https://user-images.githubusercontent.com/16785131/87547382-024a7d00-c679-11ea-94a6-db20b165a492.png)